### PR TITLE
Zmiany w pliku POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
         <selenium.version>3.14.0</selenium.version>
         <allure.version>2.7.0</allure.version>
         <spring.version>5.1.1.RELEASE</spring.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>
@@ -74,12 +76,13 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.2</version>
+            <version>1.18.8</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.7</version>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.0-alpha0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Cześć,
proponuję poniższe zmiany w pliku pom.xml tak aby wyeliminować upierdliwy błąd w kodzie, związany z użyciem biblioteki lombok i slf4j.

Dodałem również kodowanie znaków jako propertasy. Czepiał się o to maven.

- specified encoding (UTF8)
- changed version of lombok and added scope
- changed version of slf4j